### PR TITLE
chore(ci): use shared workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   ci:
-    uses: Truthdb/.github/.github/workflows/rust-ci.yml@issue-17-workflows
+    uses: Truthdb/.github/.github/workflows/rust-ci.yml@workflows-v1
     with:
       install_packages: musl-tools
       rustup_targets: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,141 +6,17 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  CARGO_TERM_COLOR: always
-  CARGO_HOME: ${{ github.workspace }}/.cargo
-  RUST_BACKTRACE: 1
-
 permissions:
   contents: read
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    container:
-      image: rust:1.92-bookworm
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust components
-        run: rustup component add rustfmt clippy
-      
-      - name: Add musl target
-        run: rustup target add x86_64-unknown-linux-musl
-      
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: .cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Cache cargo index
-        uses: actions/cache@v4
-        with:
-          path: .cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Cache target directory
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-target-lint-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Check formatting
-        run: cargo fmt -- --check
-      
-      - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    container:
-      image: rust:1.92-bookworm
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Install musl tools
-        run: |
-          apt-get update
-          apt-get install -y musl-tools
-      
-      - name: Add musl target
-        run: rustup target add x86_64-unknown-linux-musl
-      
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: .cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Cache cargo index
-        uses: actions/cache@v4
-        with:
-          path: .cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Cache target directory
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-target-test-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Run tests
-        run: cargo test --target x86_64-unknown-linux-musl
-
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    container:
-      image: rust:1.92-bookworm
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Install musl tools
-        run: |
-          apt-get update
-          apt-get install -y musl-tools
-      
-      - name: Add musl target
-        run: rustup target add x86_64-unknown-linux-musl
-      
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: .cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Cache cargo index
-        uses: actions/cache@v4
-        with:
-          path: .cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Cache target directory
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-target-build-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Build release
-        run: cargo build --release --target x86_64-unknown-linux-musl
-      
-      - name: Check binary
-        run: |
-          ls -lh target/x86_64-unknown-linux-musl/release/truthdb-installer
-          file target/x86_64-unknown-linux-musl/release/truthdb-installer
-      
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: truthdb-installer
-          path: target/x86_64-unknown-linux-musl/release/truthdb-installer
-          if-no-files-found: error
+  ci:
+    uses: Truthdb/.github/.github/workflows/rust-ci.yml@issue-17-workflows
+    with:
+      install_packages: musl-tools
+      rustup_targets: |
+        x86_64-unknown-linux-musl
+      cargo_test_command: cargo test --target x86_64-unknown-linux-musl
+      cargo_build_command: cargo build --release --target x86_64-unknown-linux-musl
+      artifact_name: truthdb-installer
+      artifact_path: target/x86_64-unknown-linux-musl/release/truthdb-installer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release:
-    uses: Truthdb/.github/.github/workflows/rust-release.yml@issue-17-workflows
+    uses: Truthdb/.github/.github/workflows/rust-release.yml@workflows-v1
     with:
       binary_name: truthdb-installer
       install_packages: musl-tools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,129 +9,18 @@ permissions:
   contents: write
 
 jobs:
-  create-release:
-    name: Create Release
-    runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-      version: ${{ steps.get_version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      
-      - name: Get version from tag
-        id: get_version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-      
-      - name: Generate release notes
-        id: release_notes
-        run: |
-          # Get the previous tag
-          PREV_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1) 2>/dev/null || echo "")
-          
-          # Generate changelog
-          if [ -z "$PREV_TAG" ]; then
-            echo "First release"
-            CHANGELOG="Initial release of TruthDB Installer"
-          else
-            CHANGELOG=$(git log ${PREV_TAG}..HEAD --pretty=format:"- %s" --no-merges)
-          fi
-          
-          # Create release body
-          cat > release_notes.md << EOF
-          ## TruthDB Installer ${GITHUB_REF#refs/tags/v}
-          
-          ### Changes
-          $CHANGELOG
-          
-          ### Installation
-          
-          Download the \`truthdb-installer\` binary for your platform and verify the checksum.
-          
-          ### Usage
-          
-          This installer is designed to run in an initramfs environment. See README.md for details.
-          EOF
-          
-          echo "notes<<EOF" >> $GITHUB_OUTPUT
-          cat release_notes.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-      
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ steps.get_version.outputs.version }}
-          body: ${{ steps.release_notes.outputs.notes }}
-          draft: false
-          prerelease: false
+  release:
+    uses: Truthdb/.github/.github/workflows/rust-release.yml@issue-17-workflows
+    with:
+      binary_name: truthdb-installer
+      install_packages: musl-tools
+      cargo_target: x86_64-unknown-linux-musl
+      artifact_target_name: x86_64-linux-musl
+      extra_body: |
+        ### Installation
 
-  build:
-    name: Build
-    needs: create-release
-    runs-on: ubuntu-latest
-    container:
-      image: rust:1.92-bookworm
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Install musl tools
-        run: |
-          apt-get update
-          apt-get install -y musl-tools
-      
-      - name: Add musl target
-        run: rustup target add x86_64-unknown-linux-musl
-      
-      - name: Build release
-        run: cargo build --release --target x86_64-unknown-linux-musl
-      
-      - name: Package binary
-        run: |
-          cd target/x86_64-unknown-linux-musl/release
-          tar czf truthdb-installer-v${{ needs.create-release.outputs.version }}-x86_64-linux-musl.tar.gz truthdb-installer
-          sha256sum truthdb-installer > truthdb-installer-v${{ needs.create-release.outputs.version }}-x86_64-linux-musl.sha256
+        Download the `truthdb-installer` binary for your platform and verify the checksum.
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-assets
-          path: |
-            target/x86_64-unknown-linux-musl/release/truthdb-installer-v${{ needs.create-release.outputs.version }}-x86_64-linux-musl.tar.gz
-            target/x86_64-unknown-linux-musl/release/truthdb-installer-v${{ needs.create-release.outputs.version }}-x86_64-linux-musl.sha256
-          if-no-files-found: error
+        ### Usage
 
-  upload:
-    name: Upload
-    needs: [create-release, build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: release-assets
-          path: dist
-      
-      - name: Upload Release Asset - Binary Archive
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./dist/truthdb-installer-v${{ needs.create-release.outputs.version }}-x86_64-linux-musl.tar.gz
-          asset_name: truthdb-installer-v${{ needs.create-release.outputs.version }}-x86_64-linux-musl.tar.gz
-          asset_content_type: application/gzip
-      
-      - name: Upload Release Asset - Checksum
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./dist/truthdb-installer-v${{ needs.create-release.outputs.version }}-x86_64-linux-musl.sha256
-          asset_name: truthdb-installer-v${{ needs.create-release.outputs.version }}-x86_64-linux-musl.sha256
-          asset_content_type: text/plain
+        This installer is designed to run in an initramfs environment. See README.md for details.


### PR DESCRIPTION
Uses reusable workflows from Truthdb/.github (workflows-v1) to remove duplicated CI/release YAML.