### PR TITLE
Fix font rendering logic to correctly interpret bitmap bytes as LSB-first, mirroring glyphs horizontally.

### DIFF
--- a/src/ui/fb.rs
+++ b/src/ui/fb.rs
@@ -224,7 +224,8 @@ impl FramebufferBackend {
         let glyph = FONT_8X8[idx];
         for (row, &byte) in glyph.iter().enumerate() {
             for col in 0..8 {
-                if byte & (1 << (7 - col)) != 0 {
+                // Font bitmap bytes are LSB-first; using MSB-first mirrors glyphs horizontally.
+                if byte & (1 << col) != 0 {
                     self.put_pixel(x + col, y + row as u32, r, g, b);
                 }
             }


### PR DESCRIPTION
## Summary

Describe what this PR changes and why.

## Checklist

- [ ] I kept the change focused and scoped
- [ ] I ran relevant tests/lints locally (or explained why not)
- [ ] I updated documentation where needed
- [ ] I considered backwards compatibility and migration impact

## Testing

Describe what you tested and how.
